### PR TITLE
Add bytes -> array[uint | address] formatting

### DIFF
--- a/contracts/universal/lib/LibBytes.sol
+++ b/contracts/universal/lib/LibBytes.sol
@@ -37,6 +37,39 @@ library Bytes {
         assembly { _output := mload(add(_input, _offst)) }
     }
 
+    /**
+     * Converts byte-arrays to an array of integers
+     */
+    function toArrayUint256(bytes memory _amounts)
+        internal
+        pure
+        returns (uint256[] memory)
+    {
+        // Format amounts
+        uint256 chunks = _amounts.length / 32;
+        uint256[] memory amountsFormatted = new uint256[](chunks);
+        for (uint256 i = 0; i < chunks; i++) {
+            amountsFormatted[i] = toUint256(i * 32 + 32, _amounts);
+        }
+        return amountsFormatted;
+    }
+
+    /**
+     * Converts byte-array to an array of addresses
+     */
+    function toArrayAddress(bytes memory _addresses)
+        internal
+        pure
+        returns (address[] memory)
+    {
+        uint256 chunks = _addresses.length / 32;
+        address[] memory addressesFormatted = new address[](chunks);
+        for (uint256 i = 0; i < chunks; i++) {
+            addressesFormatted[i] = toAddress(i * 32 + 32, _addresses);
+        }
+        return addressesFormatted;
+    }
+
     function mergeBytes(bytes memory a, bytes memory b)
         internal
         pure


### PR DESCRIPTION
The formatting of `bytes memory` into array of amounts or addresses is implemented. This will be used in the Router update, and it makes sense to put this into the same "Bytes Manipulation" library.

Feel free to rename the implemented methods for consistency, it's not crucial.